### PR TITLE
perf: pre-compute FFT plan

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageSmooth"
 uuid = "a14a6c0f-317a-4379-b4a0-4ba4e1e9b5ed"
 authors = ["Johnny Chen <johnnychen94@hotmail.com>", "JKay <2439951158@qq.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"

--- a/src/algorithms/l0_smooth.jl
+++ b/src/algorithms/l0_smooth.jl
@@ -128,6 +128,9 @@ function (f::L0Smooth)(out::GenericGrayImage,
     t¹ = trues(N, M)
     ℱ𝑆 = similar(ℱ𝐼)
 
+    # precompute the FFT plan so that we get fast FFT inside the iteration
+    F = plan_fft!(ℱ𝐼, (1, 2))
+    IF = plan_ifft!(ℱ𝐼, (1, 2))
     while 𝛽 < 𝛽max
         # Computing (ℎ, 𝑣) via solving equation (9) in [1]
         # We get the solution (12) in [1] through following process
@@ -152,14 +155,13 @@ function (f::L0Smooth)(out::GenericGrayImage,
         # 𝛥₁ᵀ() and 𝛥₂ᵀ() indicate the transposition of forward difference along horizontal axis and vertical axis
         fdiff!(𝛥₁ᵀℎ, 𝛥₁𝑆, dims = 2, rev=true, boundary=:periodic)
         fdiff!(𝛥₂ᵀ𝑣, 𝛥₂𝑆, dims = 1, rev=true, boundary=:periodic)
-        @. 𝛥₁ᵀℎ = -𝛥₁ᵀℎ
-        @. 𝛥₂ᵀ𝑣 = -𝛥₂ᵀ𝑣
 
         # Computing S via equation (8) in [1]
-        @. Normin = complex(𝛥₁ᵀℎ + 𝛥₂ᵀ𝑣)
-        fft!(Normin, (1, 2))
+        @. Normin = complex(-𝛥₁ᵀℎ - 𝛥₂ᵀ𝑣)
+        F * Normin # fft!(Normin, (1, 2))
+
         @. ℱ𝑆 = (ℱ𝐼 + 𝛽 * Normin) / (1 + 𝛽 * Denormin)
-        ifft!(ℱ𝑆, (1, 2))
+        IF * ℱ𝑆 # ifft!(ℱ𝑆, (1, 2))
         @. 𝑆 = real(ℱ𝑆)
 
         𝛽 = 𝛽 * 𝜅


### PR DESCRIPTION
```julia
using TestImages
using ImageSmooth

img = testimage("cameraman")

fₛ = L0Smooth() # using default arguements
imgₛ = smooth(img, fₛ)
```

This drops the runtime from ~280ms to ~240ms in my machine.

cc: @JKay0327 